### PR TITLE
Give the user the choice to modify the 20 items request limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ prismic:
             permalink: /posts/:slug-:id/
             # Layout file for this collection
             layout: prismic_post.html
+            # Max quantity of items (optional, default is 20)
+            page_size: 100
             # Additional queries (optional)
             query:
                 - ["missing", "my.post.allow_comments"]

--- a/lib/jekyll/prismic/collection.rb
+++ b/lib/jekyll/prismic/collection.rb
@@ -39,6 +39,10 @@ module Jekyll
         if @config['orderings'] != nil
           form.orderings(@config['orderings'])
         end
+        
+        if @config['page_size'] != nil
+          form.page_size(@config['page_size'])
+        end
 
         begin
           response = form.submit()


### PR DESCRIPTION
Added `page_size` to collections file in order for the user to be able to modify the 20 limit of the request, now up to 100.

Added it to README.md